### PR TITLE
Remove ProvisionerReference label selector

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -269,12 +269,11 @@ non-controlling OwnerReference on the EventType resources it knows about.
 
 ### ProvisionerReference
 
-| Field                | Type            | Description | Limitations                   |
-| -------------------- | --------------- | ----------- | ----------------------------- |
-| ref<sup>1</sup>      | ObjectReference |             |                               |
-| selector<sup>1</sup> | LabelSelector   |             | Must match only one resource. |
+| Field | Type            | Description | Limitations |
+| ----- | --------------- | ----------- | ----------- |
+| ref\* | ObjectReference |             |             |
 
-1: One of (name, selector), Required.
+\*: Required
 
 ### EndpointSpec
 


### PR DESCRIPTION
The requirement that the selector only match a single resource is
impossible in enforce. Label selectors are typically used to query for a
set of resources. For this field to be implemented, every Provisioner
would need to test the selector on itself.