### PR TITLE
Clarify that only a Channel is subscribable

### DIFF
--- a/docs/spec/interfaces.md
+++ b/docs/spec/interfaces.md
@@ -6,27 +6,6 @@
 
 ---
 
-## Subscribable
-
-A **Subscribable** resource will emit events that one or more _Subscription_
-can direct to their configured destination.
-
-### Control Plane
-
-A **Subscribable** resource may be referenced in the _from_ field of a
-_Subscription_. The _Subscribable_ resource MUST expose a
-_status.subscribable.channelable_ field (an _ObjectReference_). The resource
-referenced in the _status.subscribable.channelable_ field MUST be a
-_Channelable_ resource; the field MAY refer back to this _Subscribable_ as a
-self referenced resource.
-
-### Data Plane
-
-A **Subscribable** resource produces or forwards events via its
-_status.subscribable.channelable_ resource.
-
----
-
 ## Channelable
 
 A **Channelable** resource contains a list of subscribers and is responsible

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -9,9 +9,7 @@ backing implementations (much like the Kubernetes Ingress resource).
 - A **Subscription** describes the transformation of an event and optional
   forwarding of a returned event.
 
-- A **Source** allows an incoming events from an external system to be
-  _Subscribable_. A _Subscription_ is used to connect these events to
-  subsequent processing steps.
+- A **Source** emits incoming events to a _Channel_.
 
 - A **Channel** provides event persistance and fanout of events from a
   well-known input address to multiple outputs described by _Subscriptions_.
@@ -33,7 +31,6 @@ eventing API defines several resources that can be reduced down to a well
 understood contracts. These eventing resource interfaces may be fulfilled by
 other Kubernetes objects and then composed in the same way as the concreate
 objects. The interfaces are ([Sinkable](interfaces.md#sinkable),
-[Subscribable](interfaces.md#subscribable),
 [Channelable](interfaces.md#channelable),
 [Targetable](interfaces.md#targetable)). For more details, see
 [Interface Contracts](interfaces.md).
@@ -46,9 +43,9 @@ _Channel_) through transformations (such as a Knative Service which processes
 CloudEvents over HTTP). A _Subscription_ controller resolves the addresses of
 transformations (`call`) and destination storage (`result`) through the
 _Targetable_ and _Sinkable_ interface contracts, and writes the resolved
-addresses to the _Subscribable_ `from` resource. _Subscriptions_ do not need to
-specify both a transformation and a storage destination, but at least one must
-be provided.
+addresses to the _Channel_ in the `from` reference. _Subscriptions_ do not
+need to specify both a transformation and a storage destination, but at least
+one must be provided.
 
 All event delivery linkage from a **Subscription** is 1:1 – only a single
 `from`, `call`, and `result` may be provided.
@@ -60,11 +57,11 @@ For more details, see [Kind: Subscription](spec.md#kind-subscription).
 **Source** represents incoming events from an external system, such as object
 creation events in a specific storage bucket, database updates in a particular
 table, or Kubernetes resource state changes. Because a _Source_ represents an
-external system, it only produces events (and is therefore _Subscribable_ by
-_Subscriptions_). _Source_ may include parameters such as specific resource
-names, event types, or credentials which should be used to establish the
-connection to the external system. The set of allowed configuration parameters
-is described by the _Provisioner_ which is referenced by the _Source_.
+external system, it only emits events. _Source_ may include parameters such as
+specific resource names, event types, or credentials which should be used to
+establish the connection to the external system. The set of allowed
+configuration parameters is described by the _Provisioner_ which is referenced
+by the _Source_.
 
 Event selection on a _Source_ is 1:N – a single _Source_ may fan out to
 multiple _Subscriptions_.

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -57,11 +57,17 @@ For more details, see [Kind: Subscription](spec.md#kind-subscription).
 **Source** represents incoming events from an external system, such as object
 creation events in a specific storage bucket, database updates in a particular
 table, or Kubernetes resource state changes. Because a _Source_ represents an
-external system, it only emits events. _Source_ may include parameters such as
-specific resource names, event types, or credentials which should be used to
+external system, it only emits events to a _Channel_. A _Source_ may include `arguments`
+such as specific resource names, event types, or credentials which should be used to
 establish the connection to the external system. The set of allowed
 configuration parameters is described by the _Provisioner_ which is referenced
 by the _Source_.
+
+Every _Source_ has exactly one _Channel_, ensuring that each _Source_ is responsible for a _single_ event delivery.
+
+### Fanout Example
+
+If we take Cloud PubSub as an example, the _Source_ resource would reference the topic name it wants to bind to. The _Provisioner_ for the _Source_ would create a PubSub subscription for it and the _Source_ starts receiving messages. If we also want to bind the **same** PubSub topic to multiple destinations, we will create a new _Source_ for **each** destination. In this model each new _Source_ will create an **independent** PubSub subscription to the **same** topic, ensuring that each Source is responsible for a single event delivery. The actual fanout is now pushed into the Cloud PubSub, yet still is resilient to failed deliveries.
 
 For more details, see [Kind: Source](spec.md#kind-source).
 

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -63,9 +63,6 @@ establish the connection to the external system. The set of allowed
 configuration parameters is described by the _Provisioner_ which is referenced
 by the _Source_.
 
-Event selection on a _Source_ is 1:N – a single _Source_ may fan out to
-multiple _Subscriptions_.
-
 For more details, see [Kind: Source](spec.md#kind-source).
 
 ## Channel

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -33,7 +33,7 @@ cannot receive events._
 | ------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | provisioner\* | ProvisionerReference               | The provisioner used to create any backing resources and configuration.                                                | Immutable.                                                |
 | arguments     | runtime.RawExtension (JSON object) | Arguments passed to the provisioner for this specific source.                                                          | Arguments must validate against provisioner's parameters. |
-| channel       | ObjectRef                          | Specify an existing channel to use to emit events. If empty, create a new Channel using the cluster/namespace default. | Source will not emit events until channel exists.         |
+| channel\*     | ObjectRef                          | Specify a Channel to target.                                                                                           | Source will not emit events until channel exists.         |
 
 \*: Required
 
@@ -41,7 +41,6 @@ cannot receive events._
 
 | Field        | Type                      | Description                                                                                  | Limitations                                              |
 | ------------ | ------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| subscribable | Subscribable              | Pointer to a channel which can be subscribed to in order to receive events from this source. |                                                          |
 | provisioned  | []ProvisionedObjectStatus | Creation status of each Channel and errors therein.                                          | It is expected that a Source list all produced Channels. |
 | conditions   | Conditions                | Source conditions.                                                                           |                                                          |
 
@@ -98,7 +97,6 @@ Subscription's call parameter._
 | Field        | Type         | Description                                                                                                                 | Limitations |
 | ------------ | ------------ | --------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | sinkable     | Sinkable     | Address to the endpoint as top-level domain that will distribute traffic over the provided targets from inside the cluster. |             |
-| subscribable | Subscribable |                                                                                                                             |             |
 | conditions   | Conditions   | Standard Subscriptions                                                                                                      |             |
 
 ##### Conditions
@@ -125,7 +123,7 @@ Subscription's call parameter._
 
 ### group: eventing.knative.dev/v1alpha1
 
-_Describes a linkage between a Subscribable and a Targetable and/or Sinkable._
+_Describes a linkage between a Channel and a Targetable and/or Sinkable._
 
 ### Object Schema
 
@@ -295,12 +293,6 @@ non-controlling OwnerReference on the EventType resources it knows about.
 | reason   | String | Detailed description describing current relationship status. |             |
 
 \*: Required
-
-### Subscribable
-
-| Field       | Type            | Description                      | Limitations |
-| ----------- | --------------- | -------------------------------- | ----------- |
-| channelable | ObjectReference | The channel used to emit events. |             |
 
 ### Channelable
 


### PR DESCRIPTION
The Subscription resource already said that the `from` property ObjectRef was required to be a Channel, but the remainder of the spec implied otherwise.

- remove Subscribable interface (it doesn't need to exist if only a single resource can be referenced by Subscriptions)
- a Source is no longer expected to ever create a Channel (a higher level resource can create both a Source and Channel)
  - Source now requires a Channel ObjectRef
- cleanup language around the role of a Source
