### PR TITLE
Replace Channelable interface with a dedicated CRD

### DIFF
--- a/docs/spec/interfaces.md
+++ b/docs/spec/interfaces.md
@@ -15,33 +15,15 @@ can direct to their configured destination.
 
 A **Subscribable** resource may be referenced in the _from_ field of a
 _Subscription_. The _Subscribable_ resource MUST expose a
-_status.subscribable.channelable_ field (an _ObjectReference_). The resource
-referenced in the _status.subscribable.channelable_ field MUST be a
-_Channelable_ resource; the field MAY refer back to this _Subscribable_ as a
+_status.subscriptions_ field (an _ObjectReference_). The resource
+referenced in the _status.subscriptions_ field MUST be a
+_ChannelSubscriptionSet_ resource; the field MAY refer back to this _Subscribable_ as a
 self referenced resource.
 
 ### Data Plane
 
 A **Subscribable** resource produces or forwards events via its
-_status.subscribable.channelable_ resource.
-
----
-
-## Channelable
-
-A **Channelable** resource contains a list of subscribers and is responsible
-for delivering events to each of them.
-
-### Control Plane
-
-The **Channelable** resource stores a list of resolved _Subscriptions_. The
-Subscription Controller is responsible for resolving any ObjectReferences (such
-as _call_ and _result_) in the _Subscription_ to network addresses.
-
-### Data Plane
-
-**Channelable** resources will attempt delivery to each of the _subscribers_
-at least once, and retry if the subscriber returns errors.
+_status.subscriptions_ resource.
 
 ---
 

--- a/docs/spec/interfaces.md
+++ b/docs/spec/interfaces.md
@@ -17,8 +17,7 @@ A **Subscribable** resource may be referenced in the _from_ field of a
 _Subscription_. The _Subscribable_ resource MUST expose a
 _status.subscriptions_ field (an _ObjectReference_). The resource
 referenced in the _status.subscriptions_ field MUST be a
-_ChannelSubscriptionSet_ resource; the field MAY refer back to this _Subscribable_ as a
-self referenced resource.
+_ChannelSubscriptionSet_ resource.
 
 ### Data Plane
 

--- a/docs/spec/interfaces.md
+++ b/docs/spec/interfaces.md
@@ -17,7 +17,7 @@ A **Subscribable** resource may be referenced in the _from_ field of a
 _Subscription_. The _Subscribable_ resource MUST expose a
 _status.subscriptions_ field (an _ObjectReference_). The resource
 referenced in the _status.subscriptions_ field MUST be a
-_ChannelSubscriptionSet_ resource.
+_ResolvedSubscriptionSet_ resource.
 
 ### Data Plane
 

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -34,7 +34,6 @@ understood contracts. These eventing resource interfaces may be fulfilled by
 other Kubernetes objects and then composed in the same way as the concreate
 objects. The interfaces are ([Sinkable](interfaces.md#sinkable),
 [Subscribable](interfaces.md#subscribable),
-[Channelable](interfaces.md#channelable),
 [Targetable](interfaces.md#targetable)). For more details, see
 [Interface Contracts](interfaces.md).
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -11,6 +11,7 @@ This document details our _Spec_ and _Status_ customizations.
 
 - [Source](#kind-source)
 - [Channel](#kind-channel)
+  - [ChannelSubscriptionSet](#kind-channelsubscriptionset)
 - [Subscription](#kind-subscription)
 - [Provider](#kind-provisioner)
 
@@ -80,7 +81,6 @@ Subscription's call parameter._
 | ------------- | ---------------------------------- | -------------------------------------------------------------------------- | ------------------------------------ |
 | provisioner\* | ProvisionerReference               | The name of the provisioner to create the resources that back the Channel. | Immutable.                           |
 | arguments     | runtime.RawExtension (JSON object) | Arguments to be passed to the provisioner.                                 |                                      |
-| channelable   | Channelable                        | Holds a list of downstream subscribers for the channel.                    |                                      |
 | eventTypes    | []String                           | An array of event types that will be passed on the Channel.                | Must be objects with kind:EventType. |
 
 \*: Required
@@ -95,11 +95,12 @@ Subscription's call parameter._
 
 #### Status
 
-| Field        | Type         | Description                                                                                                                 | Limitations |
-| ------------ | ------------ | --------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| sinkable     | Sinkable     | Address to the endpoint as top-level domain that will distribute traffic over the provided targets from inside the cluster. |             |
-| subscribable | Subscribable |                                                                                                                             |             |
-| conditions   | Conditions   | Standard Subscriptions                                                                                                      |             |
+| Field         | Type         | Description                                                                                                                 | Limitations |
+| ------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| sinkable      | Sinkable     | Address to the endpoint as top-level domain that will distribute traffic over the provided targets from inside the cluster. |             |
+| subscribable  | Subscribable |                                                                                                                             |             |
+| conditions    | Conditions   | Standard Subscriptions                                                                                                      |             |
+| subscriptions | ObjectRef    | Reference to the ChannelSubscriptionSet for this Channel.                                                                   |             |
 
 ##### Conditions
 
@@ -118,6 +119,31 @@ Subscription's call parameter._
 | Create | The Provisioner referenced will take ownership of the Channel and begin provisioning the backing resources required for the Channel depending on implementation. | Only one Provisioner is allowed to be the Owner for a given Channel. |
 | Update | The Provisioner will synchronize the Channel backing resources to reflect the update.                                                                            |                                                                      |
 | Delete | The Provisioner will deprovision the backing resources if no longer required depending on implementation.                                                        |                                                                      |
+
+---
+
+## kind: ChannelSubscriptionSet
+
+### group: eventing.internal.knative.dev/v1alpha1
+
+_A ChannelSubscriptionSet holds an aggregation of resolved subscriptions for a
+Channel._
+
+### Object Schema
+
+#### Spec
+
+| Field         | Type                    | Description                                                           | Limitations                            |
+| ------------- | ----------------------- | --------------------------------------------------------------------- | -------------------------------------- |
+| subscribers\* | ChannelSubscriberSpec[] | Information about subscriptions used to implement message forwarding. | Filled out by Subscription Controller. |
+
+\*: Required
+
+#### Metadata
+
+##### Owner References
+
+- Owned (controlling) by the Channel the subscribers are for.
 
 ---
 
@@ -298,15 +324,9 @@ non-controlling OwnerReference on the EventType resources it knows about.
 
 ### Subscribable
 
-| Field       | Type            | Description                      | Limitations |
-| ----------- | --------------- | -------------------------------- | ----------- |
-| channelable | ObjectReference | The channel used to emit events. |             |
-
-### Channelable
-
-| Field       | Type                    | Description                                                           | Limitations                            |
-| ----------- | ----------------------- | --------------------------------------------------------------------- | -------------------------------------- |
-| subscribers | ChannelSubscriberSpec[] | Information about subscriptions used to implement message forwarding. | Filled out by Subscription Controller. |
+| Field         | Type            | Description                                                        | Limitations                       |
+| ------------- | --------------- | ------------------------------------------------------------------ | --------------------------------- |
+| subscriptions | ObjectReference | The ChannelSubscriptionSet used to collect resolved Subscriptions. | Must be a ChannelSubscriptionSet. |
 
 ### ChannelSubscriberSpec
 


### PR DESCRIPTION
- add ChannelSubscriptionSet CRD
- remove Channelable interface
- define that a ChannelSubscriptionSet is created for a Channel by the
  Provisioner and referenced in the ChannelStatus
- update definition of Subscribeable

Fixes knative/eventing#512

This PR conflicts with #4, but is authored to allow either to merge merged independently. The second to merge will need to be rebased.