### PR TITLE
Define Provisoner parameters

### DIFF
--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -90,7 +90,7 @@ See [Kind: Channel](spec.md#kind-channel).
 
 **Provisioner** catalogs available implementations of event _Sources_ and
 _Channels_. _Provisioners_ hold a JSON Schema that is used to validate the
-_Source_ and _Channel_ input parameters. _Provisioners_ make it possible to
+_Source_ and _Channel_ input arguments. _Provisioners_ make it possible to
 provide cluster wide defaults for the _Sources_ and _Channels_ they provision.
 
 _Provisioners_ do not directly handle events. They are 1:N with _Sources_ and

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -181,9 +181,10 @@ or a Channel system that receives and delivers events._
 
 #### Spec
 
-| Field  | Type                                                                            | Description                                 | Limitations                |
-| ------ | ------------------------------------------------------------------------------- | ------------------------------------------- | -------------------------- |
-| type\* | [GroupKind](https://godoc.org/k8s.io/apimachinery/pkg/runtime/schema#GroupKind) | The type of the resource to be provisioned. | Must be Source or Channel. |
+| Field      | Type                                                                            | Description                                                                 | Limitations                |
+| ---------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | -------------------------- |
+| type\*     | [GroupKind](https://godoc.org/k8s.io/apimachinery/pkg/runtime/schema#GroupKind) | The type of the resource to be provisioned.                                 | Must be Source or Channel. |
+| parameters | runtime.RawExtension (JSON object)                                              | Description of the arguments able to be passed by the provisioned resource. | JSON Schema                |
 
 \*: Required
 


### PR DESCRIPTION
Provisioned resources are able to define arguments to the provisioner.
The provisioner needs to describe what arguments are valid in some way
in order for tooling to provide any support for users beyond a black
box.

The overview already states that the provisioner is to define a JSON
schema to validate the args, but does not say where that schema exists.