### PR TITLE
Provisioner kind -> ClusterProvisioner

### DIFF
--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -3,7 +3,7 @@
 The API defines and provides a complete implementation for
 [Subscription](spec.md#kind-subscription), and abstract resource definitions
 for [Sources](spec.md#kind-source), [Channels](spec.md#kind-channel), and
-[Providers](spec.md#kind-provisioner) which may be fulfilled by multiple
+[ClusterProvisioner](spec.md#kind-clusterprovisioner) which may be fulfilled by multiple
 backing implementations (much like the Kubernetes Ingress resource).
 
 - A **Subscription** describes the transformation of an event and optional
@@ -96,7 +96,7 @@ provide cluster wide defaults for the _Sources_ and _Channels_ they provision.
 _Provisioners_ do not directly handle events. They are 1:N with _Sources_ and
 _Channels_.
 
-For more details, see [Kind: Provider](spec.md#kind-provisioner).
+For more details, see [Kind: ClusterProvisioner](spec.md#kind-clusterprovisioner).
 
 ---
 

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -86,23 +86,25 @@ multiple _Subscriptions_.
 
 See [Kind: Channel](spec.md#kind-channel).
 
-## ClusterProvisioner
+## Provisioner
 
-**ClusterProvisioners** are responsible for maintainig a catalog of available _Sources_ and _Channels_ and realizing them when required.
-ClusterProvisioners are not required to instantiate all dependent resources of a _Source_ or a _Channel_ but may instead interact with external systems.
+**ClusterProvisioners** are responsible for realizing _Sources_ and _Channels_ when required.
+Collectively they define the set of _Sources_ and _Channels_ which can be deployed into Knative.
+_ClusterProvisioners_ are not required to instantiate all dependent resources of a _Source_ or a _Channel_ but may instead interact with pre-existing systems.
 For example, the provisioner of a _Channel_ may interact with a message broker to create the required messaging endpoints, such as GC PubSub topics, rather than instantiating the message broker itself.
 
-_Sources_ and _Channels_ reference a ClusterProvisioner and can supply input arguments, eg. the URL of a message broker that a _Source_ will consume messages from. 
-These arguments are validated against a JSON Schema that the ClusterProvisioner can hold.
-The JSON Schema is also able to supply cluster wide defaults for the resources they create.
+_Sources_ and _Channels_ reference a _ClusterProvisioner_ and can supply input arguments, eg. the URL of a message broker that a _Source_ will consume messages from.
+In future, the _ClusterProvisioner_ may provide defaults for arguments and validate arguments against a JSON Schema that it holds.
 
-As an example, consider a _Source_ which connects Knative Eventing to an extenal email system.
-The developer of this _Source_ would write the application code for connecting via a suitable protocol (IMAP, SMTP, POP3,...) and package this into a container. 
-They would also write a _ClusterProvisioner_ which is able to deploy the container into Kubernetes.
-When a user provisions the _EmailSource_ they would provide connection arguments which the _ClusterProvisioner_ will use to configure the _Source_ (eg. mail servers, credentials, etc.). They can optionally supply a reference to an existing _Channel_ but if this is empty a new one will be created using the cluster/namespace defaults.
+As an example, consider a _Source_ which connects Knative Eventing to an external email system.
+In order to achieve this a developer would write the application code for connecting via a suitable protocol (IMAP, SMTP, POP3,...) and package this into an image.
+They would also create a _ClusterProvisioner_ which is capable of deploying the image into Kubernetes (for simple _Sources_ generic _ClusterProvisioners_ may be available).
+The _ClusterProvisioner_ can now be used to provision the _Source_ by other users.
+When a user deploys the _Source_ they can provide connection arguments which the _ClusterProvisioner_ will use to configure the image (eg. mail servers, credentials, etc.).
+When deploying the _Source_ an optional reference to an existing _Channel_ can be specified but if this is empty a new one will be created using the cluster/namespace defaults.
 
-_ClusterProvisioners_ do not directly handle events. 
-One ClusterProvisioner may be able to realize multiple _Channels_ and _Sources_ - they are 1:N.
+_ClusterProvisioners_ do not directly handle events.
+One _ClusterProvisioner_ must be able to realize multiple _Channels_ or _Sources_ - they are 1:N.
 
 For more details, see [Kind: ClusterProvisioner](#kind-clusterprovisioner)
 

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -86,17 +86,25 @@ multiple _Subscriptions_.
 
 See [Kind: Channel](spec.md#kind-channel).
 
-## Provisioner
+## ClusterProvisioner
 
-**Provisioner** catalogs available implementations of event _Sources_ and
-_Channels_. _Provisioners_ hold a JSON Schema that is used to validate the
-_Source_ and _Channel_ input parameters. _Provisioners_ make it possible to
-provide cluster wide defaults for the _Sources_ and _Channels_ they provision.
+**ClusterProvisioners** are responsible for maintainig a catalog of available _Sources_ and _Channels_ and realizing them when required.
+ClusterProvisioners are not required to instantiate all dependent resources of a _Source_ or a _Channel_ but may instead interact with external systems.
+For example, the provisioner of a _Channel_ may interact with a message broker to create the required messaging endpoints, such as GC PubSub topics, rather than instantiating the message broker itself.
 
-_Provisioners_ do not directly handle events. They are 1:N with _Sources_ and
-_Channels_.
+_Sources_ and _Channels_ reference a ClusterProvisioner and can supply input arguments, eg. the URL of a message broker that a _Source_ will consume messages from. 
+These arguments are validated against a JSON Schema that the ClusterProvisioner can hold.
+The JSON Schema is also able to supply cluster wide defaults for the resources they create.
 
-For more details, see [Kind: ClusterProvisioner](spec.md#kind-clusterprovisioner).
+As an example, consider a _Source_ which connects Knative Eventing to an extenal email system.
+The developer of this _Source_ would write the application code for connecting via a suitable protocol (IMAP, SMTP, POP3,...) and package this into a container. 
+They would also write a _ClusterProvisioner_ which is able to deploy the container into Kubernetes.
+When a user provisions the _EmailSource_ they would provide connection arguments which the _ClusterProvisioner_ will use to configure the _Source_ (eg. mail servers, credentials, etc.). They can optionally supply a reference to an existing _Channel_ but if this is empty a new one will be created using the cluster/namespace defaults.
+
+_ClusterProvisioners_ do not directly handle events. 
+One ClusterProvisioner may be able to realize multiple _Channels_ and _Sources_ - they are 1:N.
+
+For more details, see [Kind: ClusterProvisioner](#kind-clusterprovisioner)
 
 ---
 

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -36,7 +36,7 @@ objects. The interfaces are ([Sinkable](interfaces.md#sinkable),
 ## Subscription
 
 **Subscriptions** describe a flow of events from one _Channel_) to the next
-Channel\* through transformations (such as a Knative Service which processes
+_Channel_ through transformations (such as a Knative Service which processes
 CloudEvents over HTTP). A _Subscription_ controller resolves the addresses of
 transformations (`call`) and destination storage (`result`) through the
 _Targetable_ and _Sinkable_ interface contracts, and writes the resolved

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -12,7 +12,7 @@ This document details our _Spec_ and _Status_ customizations.
 - [Source](#kind-source)
 - [Channel](#kind-channel)
 - [Subscription](#kind-subscription)
-- [Provider](#kind-provisioner)
+- [ClusterProvisioner](#kind-clusterprovisioner)
 
 ---
 
@@ -170,7 +170,7 @@ _Describes a linkage between a Subscribable and a Targetable and/or Sinkable._
 
 ---
 
-## kind: Provisioner
+## kind: ClusterProvisioner
 
 ### group: eventing.knative.dev/v1alpha1
 


### PR DESCRIPTION
There is no Provisioner CRD in the current implementation. The CRD is
named ClusterProvisioner. "Provisioner" is still a concept and other
references in the spec are able to handle either a Provisioner or
ClusterProvisioner in the future.

Supersedes #6

cc @matzew