### PR TITLE
Trying stuff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	knative.dev/hack v0.0.0-20210309141825-9b73a256fd9a
 	knative.dev/pkg v0.0.0-20210311174826-40488532be3f
-	knative.dev/reconciler-test v0.0.0-20210311161026-af80deacbe19
+	knative.dev/reconciler-test v0.0.0-20210312233400-e0697952bd54
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1077,11 +1077,10 @@ k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/hack v0.0.0-20210309141825-9b73a256fd9a h1:0UGKyvFzY1Czu0lP9+0IrJhwtKe2oNLI2GYa7MIQ5c0=
 knative.dev/hack v0.0.0-20210309141825-9b73a256fd9a/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/pkg v0.0.0-20210310173525-bbe0bb3eb1e0/go.mod h1:pn/vClSL/iCW40TlFR91EhtmMmsyPQR2V2LavDAOOMs=
 knative.dev/pkg v0.0.0-20210311174826-40488532be3f h1:WBgC84Ldkyvt+25osB1pfrNXH9LKoXvr3BptANZWvIE=
 knative.dev/pkg v0.0.0-20210311174826-40488532be3f/go.mod h1:pn/vClSL/iCW40TlFR91EhtmMmsyPQR2V2LavDAOOMs=
-knative.dev/reconciler-test v0.0.0-20210311161026-af80deacbe19 h1:0id8XUumADTmRExY8tHjP65A+u6I189nabbN2fWnZwE=
-knative.dev/reconciler-test v0.0.0-20210311161026-af80deacbe19/go.mod h1:BqljHB9eQj66yPyxOj62syip0ZZtiG0lw76XrtRe36M=
+knative.dev/reconciler-test v0.0.0-20210312233400-e0697952bd54 h1:+NGmAy3qnE/1UZXGO2dNE4Xz94nI9ArrV6StrVP5KlE=
+knative.dev/reconciler-test v0.0.0-20210312233400-e0697952bd54/go.mod h1:xLwRGlh70/Y+W5EVHprlfkEzE5ytDLynnOzKFEIeiLg=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -1077,7 +1077,6 @@ k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/hack v0.0.0-20210309141825-9b73a256fd9a h1:0UGKyvFzY1Czu0lP9+0IrJhwtKe2oNLI2GYa7MIQ5c0=
 knative.dev/hack v0.0.0-20210309141825-9b73a256fd9a/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/pkg v0.0.0-20210310173525-bbe0bb3eb1e0 h1:j1YS+xEsmRLnhmrSwr6Skg3xsJcQpUGFzkoGtAaBx6I=
 knative.dev/pkg v0.0.0-20210310173525-bbe0bb3eb1e0/go.mod h1:pn/vClSL/iCW40TlFR91EhtmMmsyPQR2V2LavDAOOMs=
 knative.dev/pkg v0.0.0-20210311174826-40488532be3f h1:WBgC84Ldkyvt+25osB1pfrNXH9LKoXvr3BptANZWvIE=
 knative.dev/pkg v0.0.0-20210311174826-40488532be3f/go.mod h1:pn/vClSL/iCW40TlFR91EhtmMmsyPQR2V2LavDAOOMs=

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -19,8 +19,10 @@ limitations under the License.
 package rekt
 
 import (
-	"knative.dev/reconciler-test/pkg/environment"
+	"os"
 	"testing"
+
+	"knative.dev/reconciler-test/pkg/environment"
 
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
@@ -108,11 +110,16 @@ func TestBrokerWithFlakyDLQ(t *testing.T) {
 
 // TestBrokerConformance
 func TestBrokerConformance(t *testing.T) {
-	class := "MTChannelBroker"
-
+	class := eventingGlobal.eventingFlags["BrokerClass"]
+	brokerFiles := eventingGlobal.eventingFlags["BrokerFiles"]
 	ctx, env := global.Environment(environment.Managed(t))
 
-	env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithBrokerClass(class)))
+	// Install and wait for a Ready Broker.
+	if brokerFiles != "" {
+		env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithBrokerClass(class), b.WithBrokerTemplateFiles("/Users/vaikas/projects/go/src/knative.dev/eventing-rabbitmq/testroot/with-operator")))
+	} else {
+		env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithBrokerClass(class))
+	}
 
 	env.TestSet(ctx, t, broker.ControlPlaneConformance("default"))
 	env.TestSet(ctx, t, broker.DataPlaneConformance("default"))

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package rekt
 
 import (
-	"os"
 	"testing"
 
 	"knative.dev/reconciler-test/pkg/environment"
@@ -110,15 +109,15 @@ func TestBrokerWithFlakyDLQ(t *testing.T) {
 
 // TestBrokerConformance
 func TestBrokerConformance(t *testing.T) {
-	class := eventingGlobal.eventingFlags["BrokerClass"]
-	brokerFiles := eventingGlobal.eventingFlags["BrokerFiles"]
+	class := eventingGlobal.eventingFlags["BrokerClass"].(string)
+	brokerFiles := eventingGlobal.eventingFlags["BrokerFiles"].(string)
 	ctx, env := global.Environment(environment.Managed(t))
 
 	// Install and wait for a Ready Broker.
 	if brokerFiles != "" {
 		env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithBrokerClass(class), b.WithBrokerTemplateFiles("/Users/vaikas/projects/go/src/knative.dev/eventing-rabbitmq/testroot/with-operator")))
 	} else {
-		env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithBrokerClass(class))
+		env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithBrokerClass(class)))
 	}
 
 	env.TestSet(ctx, t, broker.ControlPlaneConformance("default"))

--- a/test/rekt/main_test.go
+++ b/test/rekt/main_test.go
@@ -36,10 +36,31 @@ import (
 // the testing config for the test run. The config will specify the cluster
 // config as well as the parsing level and state flags.
 var global environment.GlobalEnvironment
+var eventingGlobal EventingGlobal
+
+type EventingGlobal struct {
+	eventingFlags map[string]interface{}
+}
 
 func init() {
 	// environment.InitFlags registers state and level filter flags.
 	environment.InitFlags(flag.CommandLine)
+	class, ok := os.LookupEnv("BROKER_CLASS")
+	if !ok {
+		panic("Brokerclass not specified with ENV BROKER_CLASS")
+	}
+
+	brokerFiles, ok := os.LookupEnv("BROKER_FILES")
+	if !ok {
+		brokerFiles = ""
+	}
+
+	eventingGlobal = EventingGlobal{
+		eventingFlags: map[string]interface{}{
+			"BrokerClass": class,
+			"BrokerFiles": brokerFiles,
+		},
+	}
 }
 
 // TestMain is the first entry point for `go test`.

--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -46,6 +46,12 @@ func WithBrokerClass(class string) CfgFn {
 	}
 }
 
+func WithBrokerTemplateFiles(dir string) CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["__brokerTemplateDir"] = dir
+	}
+}
+
 // WithDeadLetterSink adds the dead letter sink related config to a Broker spec.
 func WithDeadLetterSink(ref *duckv1.KReference, uri string) CfgFn {
 	return func(cfg map[string]interface{}) {
@@ -98,6 +104,13 @@ func Install(name string, opts ...CfgFn) feature.StepFn {
 	}
 	for _, fn := range opts {
 		fn(cfg)
+	}
+	if dir, ok := cfg["__brokerTemplateDir"]; ok {
+		return func(ctx context.Context, t feature.T) {
+			if _, err := manifest.InstallYaml(ctx, dir.(string), cfg); err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 	return func(ctx context.Context, t feature.T) {
 		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {

--- a/test/rekt/resources/broker/broker.yaml
+++ b/test/rekt/resources/broker/broker.yaml
@@ -18,7 +18,7 @@ metadata:
   name: {{ .name }}
   namespace: {{ .namespace }}
   {{ if .brokerClass }}
-  labels:
+  annotations:
     eventing.knative.dev/broker.class: {{ .brokerClass }}
   {{ end }}
 spec:

--- a/vendor/knative.dev/reconciler-test/pkg/environment/magic.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/magic.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -86,6 +87,13 @@ func (mr *MagicEnvironment) Finish() {
 		panic(err)
 	}
 	mr.milestones.Finished()
+}
+
+// WithPollTimings is an environment option to override default poll timings.
+func WithPollTimings(interval, timeout time.Duration) EnvOpts {
+	return func(ctx context.Context, env Environment) (context.Context, error) {
+		return ContextWithPollTimings(ctx, interval, timeout), nil
+	}
 }
 
 // Managed enables auto-lifecycle management of the environment. Including:

--- a/vendor/knative.dev/reconciler-test/pkg/environment/namespace.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/namespace.go
@@ -19,18 +19,12 @@ package environment
 import (
 	"context"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-)
-
-const (
-	interval = 1 * time.Second
-	timeout  = 45 * time.Second
 )
 
 // CreateNamespaceIfNeeded creates a new namespace if it does not exist.
@@ -53,6 +47,8 @@ func (mr *MagicEnvironment) CreateNamespaceIfNeeded() error {
 		}
 		mr.namespaceCreated = true
 		mr.milestones.NamespaceCreated(mr.namespace)
+
+		interval, timeout := PollTimingsFromContext(mr.c)
 
 		// https://github.com/kubernetes/kubernetes/issues/66689
 		// We can only start creating pods after the default ServiceAccount is created by the kube-controller-manager.

--- a/vendor/knative.dev/reconciler-test/pkg/environment/t.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/t.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package environment
 
 import (

--- a/vendor/knative.dev/reconciler-test/pkg/environment/timings.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/timings.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package environment
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	DefaultPollInterval = 3 * time.Second
+	DefaultPollTimeout  = 2 * time.Minute
+)
+
+type timingsKey struct{}
+type timingsType struct {
+	interval time.Duration
+	timeout  time.Duration
+}
+
+// PollTimingsFromContext will get the previously set poll timing from context,
+// or return the defaults if not found.
+// - values from from context.
+// - defaults.
+func ContextWithPollTimings(ctx context.Context, interval, timeout time.Duration) context.Context {
+	return context.WithValue(ctx, timingsKey{}, timingsType{
+		interval: interval,
+		timeout:  timeout,
+	})
+}
+
+// PollTimingsFromContext will get the previously set poll timing from context,
+// or return the defaults if not found.
+// - values from from context.
+// - defaults.
+func PollTimingsFromContext(ctx context.Context) (time.Duration, time.Duration) {
+	if t, ok := ctx.Value(timingsKey{}).(timingsType); ok {
+		return t.interval, t.interval
+	}
+	return DefaultPollInterval, DefaultPollTimeout
+}

--- a/vendor/knative.dev/reconciler-test/pkg/k8s/job.go
+++ b/vendor/knative.dev/reconciler-test/pkg/k8s/job.go
@@ -33,7 +33,10 @@ import (
 )
 
 // WaitUntilJobDone waits until a job has finished.
-func WaitUntilJobDone(client kubernetes.Interface, namespace, name string, interval, timeout time.Duration) error {
+// Timing is optional but if provided is [interval, timeout].
+func WaitUntilJobDone(ctx context.Context, client kubernetes.Interface, namespace, name string, timing ...time.Duration) error {
+	interval, timeout := pollTimings(ctx, timing)
+
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		job, err := client.BatchV1().Jobs(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
@@ -54,7 +57,10 @@ func WaitUntilJobDone(client kubernetes.Interface, namespace, name string, inter
 }
 
 // WaitForJobTerminationMessage waits for a job to end and then collects the termination message.
-func WaitForJobTerminationMessage(client kubernetes.Interface, namespace, name string, interval, timeout time.Duration) (string, error) {
+// Timing is optional but if provided is [interval, timeout].
+func WaitForJobTerminationMessage(ctx context.Context, client kubernetes.Interface, namespace, name string, timing ...time.Duration) (string, error) {
+	interval, timeout := pollTimings(ctx, timing)
+
 	// poll until the pod is terminated.
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		pod, err := GetJobPodByJobName(context.Background(), client, namespace, name)

--- a/vendor/knative.dev/reconciler-test/pkg/k8s/steps.go
+++ b/vendor/knative.dev/reconciler-test/pkg/k8s/steps.go
@@ -39,9 +39,10 @@ import (
 )
 
 // IsReady returns a reusable feature.StepFn to assert if a resource is ready
-// within the time given.
-func IsReady(gvr schema.GroupVersionResource, name string, interval, timeout time.Duration) feature.StepFn {
+// within the time given. Timing is optional but if provided is [interval, timeout].
+func IsReady(gvr schema.GroupVersionResource, name string, timing ...time.Duration) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
+		interval, timeout := pollTimings(ctx, timing)
 		env := environment.FromContext(ctx)
 		if err := WaitForResourceReady(ctx, env.Namespace(), name, gvr, interval, timeout); err != nil {
 			t.Error(gvr, "did not become ready,", err)
@@ -50,9 +51,10 @@ func IsReady(gvr schema.GroupVersionResource, name string, interval, timeout tim
 }
 
 // IsAddressable tests to see if a resource becomes Addressable within the time
-// given.
-func IsAddressable(gvr schema.GroupVersionResource, name string, interval, timeout time.Duration) feature.StepFn {
+// given. Timing is optional but if provided is [interval, timeout].
+func IsAddressable(gvr schema.GroupVersionResource, name string, timing ...time.Duration) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
+		interval, timeout := pollTimings(ctx, timing)
 		lastMsg := ""
 		err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 			addr, err := Address(ctx, gvr, name)

--- a/vendor/knative.dev/reconciler-test/pkg/manifest/installer.go
+++ b/vendor/knative.dev/reconciler-test/pkg/manifest/installer.go
@@ -30,16 +30,11 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 )
 
-func InstallLocalYaml(ctx context.Context, base map[string]interface{}) (Manifest, error) {
+func InstallYaml(ctx context.Context, dir string, base map[string]interface{}) (Manifest, error) {
 	env := environment.FromContext(ctx)
 	cfg := env.TemplateConfig(base)
 
-	pwd, _ := os.Getwd()
-	log.Println("PWD: ", pwd)
-	_, filename, _, _ := runtime.Caller(1)
-	log.Println("FILENAME: ", filename)
-
-	yamls, err := ParseTemplates(path.Dir(filename), env.Images(), cfg)
+	yamls, err := ParseTemplates(dir, env.Images(), cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -66,6 +61,16 @@ func InstallLocalYaml(ctx context.Context, base map[string]interface{}) (Manifes
 		log.Println(ref)
 	}
 	return manifest, nil
+
+}
+
+func InstallLocalYaml(ctx context.Context, base map[string]interface{}) (Manifest, error) {
+	pwd, _ := os.Getwd()
+	log.Println("PWD: ", pwd)
+	_, filename, _, _ := runtime.Caller(1)
+	log.Println("FILENAME: ", filename)
+
+	return InstallYaml(ctx, path.Dir(filename), base)
 }
 
 func ImagesLocalYaml() []string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1090,7 +1090,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20210311161026-af80deacbe19
+# knative.dev/reconciler-test v0.0.0-20210312233400-e0697952bd54
 ## explicit
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- This patch allows one to run templates from different locations and using different (non-hardcoded brokerclasses for example). I used rabbitmq as an example. The test run used was:

```
BROKER_CLASS=RabbitMQBroker BROKER_FILES=/Users/vaikas/projects/go/src/knative.dev/eventing-rabbitmq/testroot/with-broker SYSTEM_NAMESPACE=knative-eventing go test -count=1 -v -tags=e2e -run TestBrokerConformance ./test/rekt/...
```

And the non-local files used were:
```
vaikas@villes-mbp eventing % find ../eventing-rabbitmq/testroot/with-operator
../eventing-rabbitmq/testroot/with-operator
../eventing-rabbitmq/testroot/with-operator/prereq.yaml
../eventing-rabbitmq/testroot/with-operator/base.yaml
vaikas@villes-mbp eventing % cat ../eventing-rabbitmq/testroot/with-operator/prereq.yaml
apiVersion: rabbitmq.com/v1beta1
kind: RabbitmqCluster
metadata:
  name: rabbitbroker
  namespace: {{ .namespace }}
spec:
  replicas: 1
vaikas@villes-mbp eventing % cat ../eventing-rabbitmq/testroot/with-operator/base.yaml
apiVersion: eventing.knative.dev/v1
kind: Broker
metadata:
  name: {{ .name }}
  namespace: {{ .namespace }}
  {{ if .brokerClass }}
  annotations:
    eventing.knative.dev/broker.class: {{ .brokerClass }}
  {{ end }}
spec:
  config:
    apiVersion: rabbitmq.com/v1beta1
    kind: RabbitmqCluster
    name: rabbitbroker
```

And the test results were:
```
--- PASS: TestBrokerConformance (58.04s)
    --- PASS: TestBrokerConformance/Prerequisite (48.13s)
        --- PASS: TestBrokerConformance/Prerequisite/Setup/install_broker_"default" (0.08s)
        --- PASS: TestBrokerConformance/Prerequisite/Assert/[Stable/MUST]broker_be_ready (48.04s)
        --- PASS: TestBrokerConformance/Prerequisite/Assert/[Stable/MUST]broker_be_addressable (0.02s)
    --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane (0.12s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane/Setup/Set_Broker_Name (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane/Assert/[Stable/SHOULD]Conformance_Broker_objects_SHOULD_include_a_Ready_condition_in_their_status (0.02s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane/Assert/[Stable/SHOULD]Conformance_The_Broker_SHOULD_indicate_Ready=True_when_its_ingress_is_available_to_receive_events. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane/Assert/[Stable/SHOULD]Conformance_While_a_Broker_is_Ready,_it_SHOULD_be_a_valid_Addressable_and_its_`status.address.url`_field_SHOULD_indicate_the_address_of_its_ingress. (0.01s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane/Assert/[Stable/SHOULD]Conformance_The_class_of_a_Broker_object_SHOULD_be_immutable. (0.09s)
    --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01 (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Setup/Set_Broker_Name (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/SHOULD]Conformance_Triggers_SHOULD_include_a_Ready_condition_in_their_status. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/SHOULD]Conformance_The_Trigger_SHOULD_indicate_Ready=True_when_events_can_be_delivered_to_its_subscriber. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/SHOULD]Conformance_While_a_Trigger_is_Ready,_it_SHOULD_indicate_its_subscriber's_URI_via_the_`status.subscriberUri`_field. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/MUST]Conformance_Triggers_MUST_be_assigned_to_exactly_one_Broker. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/MUST]Conformance_The_assigned_Broker_of_a_Trigger_SHOULD_be_immutable. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/SHOULD]Conformance_Triggers_SHOULD_be_assigned_a_default_Broker_upon_creation_if_no_Broker_is_specified_by_the_user. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/MAY]Conformance_A_Trigger_MAY_be_created_before_its_assigned_Broker_exists. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/SHOULD]Conformance_A_Trigger_SHOULD_progress_to_Ready_when_its_assigned_Broker_exists_and_is_Ready. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/MUST]Conformance_The_attributes_filter_specifying_a_list_of_key-value_pairs_MUST_be_supported_by_Trigger. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#01/Assert/[Stable/MUST]Conformance_Events_that_pass_the_attributes_filter_MUST_include_context_or_extension_attributes_that_match_all_key-value_pairs_exactly. (0.00s)
    --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#02 (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#02/Setup/Set_Broker_Name (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#02/Assert/[Stable/SHOULD]Conformance_When_`BrokerSpec.Delivery`_and_`TriggerSpec.Delivery`_are_both_not_configured,_no_delivery_spec_SHOULD_be_used. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#02/Assert/[Stable/SHOULD]Conformance_When_`BrokerSpec.Delivery`_is_configured,_but_not_the_specific_`TriggerSpec.Delivery`,_then_the_`BrokerSpec.Delivery`_SHOULD_be_used. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Control_Plane#02/Assert/[Stable/SHOULD]Conformance_When_`TriggerSpec.Delivery`_is_configured,_then_`TriggerSpec.Delivery`_SHOULD_be_used. (0.00s)
    --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Setup/Set_Broker_Name (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/SHOULD]Conformance_A_Broker_SHOULD_expose_either_an_HTTP_or_HTTPS_endpoint_as_ingress._It_MAY_expose_both. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/MUST]Conformance_The_ingress_endpoint(s)_MUST_conform_to_at_least_one_of_the_following_versions_of_the_specification:_0.3,_1.0 (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/MAY]Conformance_Other_versions_MAY_be_rejected. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/SHOULD_NOT]Conformance_The_Broker_SHOULD_NOT_perform_an_upgrade_of_the_produced_event's_CloudEvents_version. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/SHOULD]Conformance_It_SHOULD_support_both_Binary_Content_Mode_and_Structured_Content_Mode_of_the_HTTP_Protocol_Binding_for_CloudEvents. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/MAY]Conformance_The_HTTP(S)_endpoint_MAY_be_on_any_port,_not_just_the_standard_80_and_443. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/MAY]Conformance_Channels_MAY_expose_other,_non-HTTP_endpoints_in_addition_to_HTTP_at_their_discretion. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/MUST]Conformance_Brokers_MUST_reject_all_HTTP_produce_requests_with_a_method_other_than_POST_responding_with_HTTP_status_code_`405_Method_Not_Supported`. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/MUST]Conformance_The_Broker_MUST_respond_with_a_200-level_HTTP_status_code_if_a_produce_request_is_accepted. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane/Assert/[Stable/MUST]Conformance_If_a_Broker_receives_a_produce_request_and_is_unable_to_parse_a_valid_CloudEvent,_then_it_MUST_reject_the_request_with_HTTP_status_code_`400_Bad_Request`. (0.00s)
    --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01 (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Setup/Set_Broker_Name (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MUST]Conformance_Delivered_events_MUST_conform_to_the_CloudEvents_specification. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/SHOULD]Conformance_All_CloudEvent_attributes_set_by_the_producer,_including_the_data_and_specversion_attributes,_SHOULD_be_received_at_the_subscriber_identical_to_how_they_were_received_by_the_Broker. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/SHOULD]Conformance_The_Broker_SHOULD_support_delivering_events_via_Binary_Content_Mode_or_Structured_Content_Mode_of_the_HTTP_Protocol_Binding_for_CloudEvents. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/SHOULD]Conformance_Events_accepted_by_the_Broker_SHOULD_be_delivered_at_least_once_to_all_subscribers_of_all_Triggers*. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MAY]Conformance_Events_MAY_additionally_be_delivered_to_Triggers_that_become_Ready_after_the_event_was_accepted. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MAY]Conformance_Events_MAY_be_enqueued_or_delayed_between_acceptance_from_a_producer_and_delivery_to_a_subscriber. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MAY]Conformance_The_Broker_MAY_choose_not_to_deliver_an_event_due_to_persistent_unavailability_of_a_subscriber_or_limitations_such_as_storage_capacity. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/SHOULD]Conformance_The_Broker_SHOULD_attempt_to_notify_the_operator_in_this_case. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MAY]Conformance_The_Broker_MAY_forward_these_events_to_an_alternate_endpoint_or_storage_mechanism_such_as_a_dead_letter_queue. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MAY]Conformance_If_no_ready_Trigger_would_match_an_accepted_event,_the_Broker_MAY_drop_that_event_without_notifying_the_producer. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MAY]Conformance_If_multiple_Triggers_reference_the_same_subscriber,_the_subscriber_MAY_be_expected_to_acknowledge_successful_delivery_of_an_event_multiple_times. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/SHOULD]Conformance_Events_contained_in_delivery_responses_SHOULD_be_published_to_the_Broker_ingress_and_processed_as_if_the_event_had_been_produced_to_the_Broker's_addressable_endpoint. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/SHOULD]Conformance_Events_contained_in_delivery_responses_that_are_malformed_SHOULD_be_treated_as_if_the_event_delivery_had_failed. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/MAY]Conformance_The_subscriber_MAY_receive_a_confirmation_that_a_reply_event_was_accepted_by_the_Broker. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#01/Assert/[Stable/SHOULD]Conformance_If_the_reply_event_was_not_accepted,_the_initial_event_SHOULD_be_redelivered_to_the_subscriber. (0.00s)
    --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#02 (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#02/Setup/Set_Broker_Name (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#02/Assert/[Stable/SHOULD]Conformance_The_Broker_SHOULD_expose_a_variety_of_metrics*. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#02/Assert/[Stable/SHOULD]Conformance_Metrics_SHOULD_be_enabled_by_default,_with_a_configuration_parameter_included_to_disable_them_if_desired. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#02/Assert/[Stable/SHOULD]Conformance_Upon_receiving_an_event_with_context_attributes_defined_in_the_CloudEvents_Distributed_Tracing_extension_the_Broker_SHOULD_preserve_that_trace_header_on_delivery_to_subscribers_and_on_reply_events,_unless_the_reply_is_sent_with_a_different_set_of_tracing_attributes. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#02/Assert/[Stable/SHOULD]Conformance_Forwarded_trace_headers_SHOULD_be_updated_with_any_intermediate_spans_emitted_by_the_broker. (0.00s)
        --- PASS: TestBrokerConformance/Knative_Broker_Specification_-_Data_Plane#02/Assert/[Stable/SHOULD]Conformance_Spans_emitted_by_the_Broker_SHOULD_follow_the_OpenTelemetry_Semantic_Conventions_for_Messaging_System*. (0.00s)
PASS
ok  	knative.dev/eventing/test/rekt	59.004s
```

-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
